### PR TITLE
The `C_VkRenderer::SetTextureData` checks number of channels #230

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [Unreleased] - 14-05-2025
+### Fixed
+- `C_VkRenderer::SetTextureData` reflects number of channels
+
 ## [Unreleased] - 13-02-2025
 
 Goal of this branch was to create water simulation. Unfortunatelly I have faild and want to move on. One day I will be hopefully able to continue.

--- a/Renderer/Renderer/Windows/RayTrace.cpp
+++ b/Renderer/Renderer/Windows/RayTrace.cpp
@@ -32,7 +32,7 @@ constexpr static unsigned int  s_ProbeSize		 = 64;
 C_RayTraceWindow::C_RayTraceWindow(const GUID guid, const std::shared_ptr<I_CameraComponent>& camera, GUI::C_GUIManager& guiMGR)
 	: GUI::C_Window(guid, "Ray tracing")
 	, m_Camera(camera)
-	, m_ImageStorage(s_ImageResolution.x / s_Coef, s_ImageResolution.y / s_Coef, 4)
+	, m_ImageStorage(s_ImageResolution.x / s_Coef, s_ImageResolution.y / s_Coef, 3)
 	, m_SamplesStorage(s_ImageResolution.x / s_Coef, s_ImageResolution.y / s_Coef, 3)
 	, m_HeatMapStorage(1, s_ImageResolution.y / s_Coef, 1)
 	, m_HeatMapNormalizedStorage(1, s_ImageResolution.y / s_Coef, 3)

--- a/VulkanRenderer/VulkanRenderer/Textures/VkTexture.h
+++ b/VulkanRenderer/VulkanRenderer/Textures/VkTexture.h
@@ -13,6 +13,8 @@ public:
 	void								SetSampler(Renderer::Handle<Renderer::Sampler> sampler);
 	Renderer::Handle<Renderer::Sampler> GetSampler() const;
 
+	const Renderer::TextureDescriptor& GetDesc() const { return m_Desc; }
+
 	VkImageView GetView() const;
 
 private:


### PR DESCRIPTION
# Describe the contribution

## Fixed issues
- #230 

## Informations
The bug with wrong display of ray tracing result on Vulkan fixed

**Checklist**
- [x] Changelist included
- [ ] ~~Tests for fixed bugs~~
- [x] Clang-format

**Test Configuration**:
* GPU: RTX 4070 Laptop GPU
* Backend: Vulkan, OpenGL
* OS:  Windows 11

**Affected backends**
- [x] CPU
- [ ] OpenGL
- [x] Vulkan
- [ ] DirectX